### PR TITLE
Add netbox-osp (outside-plant + inter-rack fibre management)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ A curated list of awesome resources related to NetBox!
 ## Plugins
 
 - [netboxlabs.com/netbox-plugins/](https://netboxlabs.com/netbox-plugins/) - NetBox Community Plugins
+- [netbox-osp](https://github.com/iamjohnnymac/netbox-osp) - Outside-plant + inter-rack fibre management: OSP cables with TIA-598-C colour coding, splice closures with measured loss, MPO/MTP trunks with one-click harness deploy, end-to-end visual core tracer with loss budget, and a Leaflet plant map with offline MBTiles fallback. No PostGIS required.
 
 ## Ansible
 


### PR DESCRIPTION
## Adding netbox-osp

This PR adds [netbox-osp](https://github.com/iamjohnnymac/netbox-osp) to the **Plugins** list.

netbox-osp is a NetBox 4.6+ plugin covering the fibre gap between NetBox core's inside-plant cabling and the actual operator surface:

- **Outside plant** — multi-tube armoured cables with TIA-598-C colour auto-assignment, splice closures with measured per-strand loss, splices on a tray + position grid, end-to-end fibre links with a computed loss budget banded ok/warn/fail.
- **Inter-rack** — \`FibreTrunk\` + \`TrunkBreakout\` model that bridges to NetBox's native \`dcim.Cable\`, so a 24F MTP trunk with two 12F cassette breakouts is one cohesive entity. A one-click "Deploy MTP Harness" form atomically creates the trunk + N cassette devices + N cables + N breakout rows in a single transaction.
- **Visual core tracer** — click "Trace this core" on any Strand / FrontPort / Interface and see the full path rendered as a dagre-d3 graph: every interface, patch cord, cassette pass-through, trunk fibre, splice, and OSP strand with per-hop loss + cumulative budget.
- **Plant map** — full-screen Leaflet at \`/plugins/osp/map/\` with seven online base layers plus a bundled offline MBTiles bundle and automatic offline fallback after three tile errors in five seconds.

Unlike adjacent fibre plugins (netbox-fms, netbox-pathways, cesnet_service_path_plugin), netbox-osp does **not** require PostGIS — plant-boundary validation and the splice walker are pure-Python, so it runs on any NetBox-supported database. Apache-2.0 licensed. Released v0.2.1 on PyPI.

- Repo: https://github.com/iamjohnnymac/netbox-osp
- Docs: https://iamjohnnymac.github.io/netbox-osp/
- PyPI: https://pypi.org/project/netbox-osp/

## Checklist

- [x] Project is publicly available on GitHub
- [x] Released on PyPI
- [x] Compatible with a currently supported NetBox version (4.6+)
- [x] Open-source licence (Apache-2.0)
- [x] Documentation site published